### PR TITLE
#29 set eeprom write protection pin to low so that writing is always …

### DIFF
--- a/device/larus/src/driver/init.rs
+++ b/device/larus/src/driver/init.rs
@@ -97,6 +97,10 @@ pub fn hw_init<'a>(
     let gpioe = dp.GPIOE.split(ccdr.peripheral.GPIOE);
     let gpiof = dp.GPIOF.split(ccdr.peripheral.GPIOF);
 
+    // Setup ----------> The EEPROM Write Protect Signal
+    let mut wp = gpioc.pc5.into_push_pull_output();
+    wp.set_low(); // Always enable writing to the eeprom 
+
     // Setup ----------> The front key interface
     let keyboard = {
         let keyboard_pins = KeyboardPins::new(gpioe.pe5, gpioe.pe6, gpioe.pe4);


### PR DESCRIPTION
…possible

Might be related to #29    but all digital signals shall be well driven all the time it its not an antenna.