### PR TITLE
Mark the worst heading in the thermal assistants

### DIFF
--- a/core/src/model/device_const.rs
+++ b/core/src/model/device_const.rs
@@ -213,9 +213,11 @@ pub struct VarioPalette {
     pub therm_ass_best: Colors,
     pub therm_ass_good: Colors,
     pub therm_ass_bad: Colors,
+    pub therm_ass_worst: Colors,
     pub therm2_ass_best: Colors,
     pub therm2_ass_good: Colors,
     pub therm2_ass_bad: Colors,
+    pub therm2_ass_worst: Colors,
 }
 
 impl VarioPalette {
@@ -242,9 +244,11 @@ impl VarioPalette {
             therm_ass_best: Colors::Yellow,
             therm_ass_good: Colors::Red,
             therm_ass_bad: Colors::DeepSkyBlue,
+            therm_ass_worst: Colors::Black,
             therm2_ass_best: Colors::Yellow,
             therm2_ass_good: Colors::Red,
             therm2_ass_bad: Colors::Blue,
+            therm2_ass_worst: Colors::Black,
         }
     }
 }

--- a/core/src/view/thermal_data.rs
+++ b/core/src/view/thermal_data.rs
@@ -15,6 +15,7 @@ pub struct ThermalData {
     last_tick: u32,
 
     best_pos: usize,
+    worst_pos: usize,
 }
 
 impl ThermalData {
@@ -46,11 +47,17 @@ impl ThermalData {
 
     pub fn prepare(&mut self) {
         self.best_pos = 0;
-        let mut value = self.climb_data[0];
+        self.worst_pos = 0;
+        let mut best_value = self.climb_data[0];
+        let mut worst_value = self.climb_data[0];
         for idx in 1..THERMAL_DATA_CNT {
-            if self.climb_data[idx] > value {
-                value = self.climb_data[idx];
+            if self.climb_data[idx] > best_value {
+                best_value = self.climb_data[idx];
                 self.best_pos = idx;
+            }
+            if self.climb_data[idx] < worst_value {
+                worst_value = self.climb_data[idx];
+                self.worst_pos = idx;
             }
         }
     }
@@ -59,6 +66,8 @@ impl ThermalData {
         let idx = Self::get_idx(alpha);
         let color = if idx == self.best_pos {
             cm.palette().vario.therm_ass_best
+        } else if idx == self.worst_pos {
+            cm.palette().vario.therm_ass_worst
         } else if self.climb_data[idx] > 0.0 {
             cm.palette().vario.therm_ass_good
         } else {
@@ -72,6 +81,8 @@ impl ThermalData {
         let idx = Self::get_idx(alpha);
         let color = if idx == self.best_pos {
             cm.palette().vario.therm2_ass_best
+        } else if idx == self.worst_pos {
+            cm.palette().vario.therm2_ass_worst
         } else if self.climb_data[idx] > 0.0 {
             cm.palette().vario.therm2_ass_good
         } else {
@@ -89,6 +100,7 @@ impl Default for ThermalData {
             last_vario_mode: VarioMode::SpeedToFly,
             last_tick: 0,
             best_pos: 0,
+            worst_pos: 0,
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR improves the thermal assistants by marking not only the best heading, but also the worst heading / weakest sector.

Changes:
- track both the best and worst thermal sector in the frontend thermal data
- add dedicated palette colors for the worst sector in:
    - dotted thermal assistant
    - spider thermal assistant

## Why

The thermal assistants already highlight where lift is strongest.
By also marking the weakest sector, the thermal structure becomes easier to interpret:

- where to move toward
- which side to avoid
- clearer distinction between strong and weak parts of the circle

## Scope

Frontend only.

## Validation

- `cargo check` passed in `core`