### PR TITLE
Add Ventus 3 18m glider polar

### DIFF
--- a/core/src/flight_physics/polar_store.rs
+++ b/core/src/flight_physics/polar_store.rs
@@ -1918,4 +1918,15 @@ pub const POLARS: &[BasicGliderData] = &[
         handicap: 116,
         polar_values: [[86.4, -0.583], [115.2, -0.642], [180.0, -1.473]],
     },
+    BasicGliderData {
+        // No 169,  self added
+        name: "Ventus 3 18m",
+        wing_area: 10.84,
+        max_speed: 250.0,
+        empty_mass: 395.0,
+        max_ballast: 140.0,
+        reference_weight: 385.0,
+        handicap: 122,
+        polar_values: [[101.6, -0.520], [150.8, -1.080], [200.0, -2.250]],
+    },
 ];

--- a/core/src/flight_physics/polar_store_idx.rs
+++ b/core/src/flight_physics/polar_store_idx.rs
@@ -164,13 +164,14 @@ pub const TO_SORTED: &'static[u8] = &[
     161, // Ventus 2cT 18m
     162, // Ventus 2cx 18m
     163, // Ventus 2cxT 18m
-    164, // Ventus a/b 16.6m
-    165, // Ventus b (15m)
-    166, // Ventus cM (17.6)
-    167, // WA 26 P Squale
-    168, // Zuni II
+    165, // Ventus a/b 16.6m
+    166, // Ventus b (15m)
+    167, // Ventus cM (17.6)
+    168, // WA 26 P Squale
+    169, // Zuni II
     7, // AS-33 18m
     6, // AS-33 15m
+    164, // Ventus 3 18m
 ];
 
 pub const TO_RAW: &'static[u8] = &[
@@ -338,6 +339,7 @@ pub const TO_RAW: &'static[u8] = &[
     159, //Ventus 2cT 18m
     160, //Ventus 2cx 18m
     161, //Ventus 2cxT 18m
+    169, //Ventus 3 18m
     162, //Ventus a/b 16.6m
     163, //Ventus b (15m)
     164, //Ventus cM (17.6)


### PR DESCRIPTION
## Summary

Adds the Schempp-Hirth Ventus 3 (18m) to the built-in polar database as entry 169.

- `core/src/flight_physics/polar_store.rs`: new `BasicGliderData` entry for "Ventus 3 18m"
- `core/src/flight_physics/polar_store_idx.rs`: regenerated `TO_SORTED` / `TO_RAW` index tables for the new entry

### Polar data

| Field | Value |
|---|---|
| wing area | 10.84 m² |
| max speed | 250 km/h |
| empty mass | 395 kg |
| max ballast | 140 kg |
| reference weight | 385 kg |
| handicap | 122 |
| polar points (km/h, m/s) | (101.6, -0.520), (150.8, -1.080), (200.0, -2.250) |

Index tables follow the same convention as the existing AS-33 entries: the new raw index is appended at the end of `TO_SORTED` rather than re-sorted alphabetically, and inserted in alphabetical position in `TO_RAW`.