### PR TITLE
Fix stale attitude output when horizon is blocked

### DIFF
--- a/core/src/controller/helpers/nmea_handler.rs
+++ b/core/src/controller/helpers/nmea_handler.rs
@@ -136,8 +136,13 @@ impl CoreController {
             let id = self.nmea_buffer.pers_id.pop_front().unwrap();
             return self.nmea_plars(cm, id);
         }
-        if let Some(idx) = self.nmea_buffer.to_send.pop() {
-            match idx {
+        let roll_pitch_available = cm.sensor.roll_pitch_available();
+        while let Some(idx) = self.nmea_buffer.to_send.pop() {
+            if idx == 6 && !roll_pitch_available {
+                continue;
+            }
+
+            return match idx {
                 // rarely sent
                 0 => Some(self.nmea_gprmc(cm)),
                 1 => Some(self.nmea_gpgga(cm)),
@@ -152,10 +157,9 @@ impl CoreController {
 
                 // not known
                 _ => None,
-            }
-        } else {
-            None
+            };
         }
+        None
     }
 
     fn nmea_gprmc(&mut self, cm: &mut CoreModel) -> &[u8] {

--- a/core/src/model/sensor.rs
+++ b/core/src/model/sensor.rs
@@ -102,6 +102,10 @@ impl Sensor {
         (self.larus_box_system_state & 0x0001_0000) != 0
     }
 
+    pub fn roll_pitch_available(&self) -> bool {
+        !self.horizon_blocked()
+    }
+
     pub fn gnss_velocity_accuracy_bad(&self) -> bool {
         (self.larus_box_system_state & 0x0000_0004) != 0
     }

--- a/core/src/view/viewable/device_lineview.rs
+++ b/core/src/view/viewable/device_lineview.rs
@@ -165,11 +165,19 @@ impl DeviceLineView {
             },
             DeviceLineView::AhrsPitch => LineInfo {
                 name: "AHRS Pitch: ",
-                value: tformat!(30, "{:.0}°", cm.sensor.euler_pitch.to_degrees()).unwrap(),
+                value: if cm.sensor.roll_pitch_available() {
+                    tformat!(30, "{:.0}°", cm.sensor.euler_pitch.to_degrees()).unwrap()
+                } else {
+                    tformat!(30, "-").unwrap()
+                },
             },
             DeviceLineView::AhrsRoll => LineInfo {
                 name: "AHRS Roll: ",
-                value: tformat!(30, "{:.0}°", cm.sensor.euler_roll.to_degrees()).unwrap(),
+                value: if cm.sensor.roll_pitch_available() {
+                    tformat!(30, "{:.0}°", cm.sensor.euler_roll.to_degrees()).unwrap()
+                } else {
+                    tformat!(30, "-").unwrap()
+                },
             },
             DeviceLineView::AhrsYaw => LineInfo {
                 name: "AHRS Yaw: ",

--- a/core/src/view/viewable/vario_infoview.rs
+++ b/core/src/view/viewable/vario_infoview.rs
@@ -677,6 +677,18 @@ fn draw_bank_angle<D>(display: &mut D, cm: &CoreModel, pos: Point) -> Result<(),
 where
     D: DrawTarget<Color = Colors, Error = CoreError> + DrawImage,
 {
+    if !cm.sensor.roll_pitch_available() {
+        return draw_centered_line(
+            display,
+            pos,
+            None,
+            "--",
+            None,
+            &cm.device_const.big_font,
+            cm.palette(),
+        );
+    }
+
     let roll_deg = cm.sensor.euler_roll.to_degrees();
     let s = tformat!(8, "{:.0}°", roll_deg.abs()).unwrap();
     let img_bytes = if roll_deg < 0.0 {
@@ -725,7 +737,11 @@ fn draw_pitch_angle<D>(display: &mut D, cm: &CoreModel, pos: Point) -> Result<()
 where
     D: DrawTarget<Color = Colors, Error = CoreError> + DrawImage,
 {
-    let s = tformat!(8, "{:.0}°", cm.sensor.euler_pitch.to_degrees()).unwrap();
+    let s = if cm.sensor.roll_pitch_available() {
+        tformat!(8, "{:.0}°", cm.sensor.euler_pitch.to_degrees()).unwrap()
+    } else {
+        heapless::String::<8>::try_from("--").unwrap()
+    };
     draw_centered_line(
         display,
         pos,


### PR DESCRIPTION
## Summary

Fix stale roll/pitch usage after the sensorbox reports the horizon as blocked.

When horizon lock becomes visible, the sensorbox stops transmitting roll/pitch, but the frontend may already have cached pre-lock attitude values. Those values were still being sent via NMEA and shown in roll/pitch UI fields.

## Changes

- Add `Sensor::roll_pitch_available()` based on the existing horizon blocked state.
- Stop sending `$PLARA` while roll/pitch are unavailable.
- Show unavailable placeholders for:
  - Vario bank angle
  - Vario pitch angle
  - Device info AHRS roll
  - Device info AHRS pitch

Yaw handling is unchanged.