### PR TITLE
Use turn-rate based circling direction for thermal assistants

### DIFF
--- a/core/src/controller/mod.rs
+++ b/core/src/controller/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     basic_config::{CONTROLLER_TICK_RATE, MAX_TX_FRAMES},
     common::PTxFrames,
     flight_physics::Polar,
-    model::{DataSource, DisplayActive, EditMode, VarioModeControl},
+    model::{CirclingDirection, DataSource, DisplayActive, EditMode, VarioModeControl},
     system_of_units::{FloatToSpeed, Speed},
     utils::{KeyEvent, PIdleEvents, Pt1},
     CPersistenceItems, CoreModel, DeviceEvent, Editable, Event, IdleEvent, InputPinState,
@@ -194,6 +194,10 @@ impl CoreController {
 
     fn tick_100ms(&mut self, core_model: &mut CoreModel) {
         core_model.control.alive_ticks = core_model.control.alive_ticks.wrapping_add(1);
+        core_model.control.circling_direction = CirclingDirection::from_turn_rate(
+            core_model.sensor.turn_rate.to_rad_s(),
+            core_model.control.circling_direction,
+        );
 
         if core_model.control.vario_mode == VarioMode::Vario {
             self.av2_climb_rate.tick(core_model.sensor.climb_rate);

--- a/core/src/model/control.rs
+++ b/core/src/model/control.rs
@@ -19,6 +19,26 @@ pub enum FlyMode {
     StraightFlight,
 }
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum CirclingDirection {
+    Left,
+    Right,
+}
+
+impl CirclingDirection {
+    pub fn from_turn_rate(turn_rate_rad_s: f32, current: Self) -> Self {
+        const MIN_TURN_RATE_RAD_S: f32 = 0.03;
+
+        if turn_rate_rad_s > MIN_TURN_RATE_RAD_S {
+            Self::Left
+        } else if turn_rate_rad_s < -MIN_TURN_RATE_RAD_S {
+            Self::Right
+        } else {
+            current
+        }
+    }
+}
+
 /// This enum is relevant for the View component. During Vario mode, information needed to
 /// optimize climbing in thermals is displayed. SppedToFly, on the other hand, is intended
 /// for optimal pre-flight.
@@ -200,6 +220,8 @@ pub struct Control {
     pub can_devices: u32,
     /// FlyMode::Circling, FlyMode::StraightFlight
     pub fly_mode: FlyMode,
+    /// Last detected circling direction
+    pub circling_direction: CirclingDirection,
     /// VarioMode::Vario, VarioMode::SpeedToFly
     pub vario_mode: VarioMode,
     /// VarioMode::Vario, VarioMode::SpeedToFly, VarioMode::Auto
@@ -250,6 +272,7 @@ impl Default for Control {
             system_state: SystemState::NoCom,
             can_devices: CanActive::None as u32,
             fly_mode: FlyMode::StraightFlight,
+            circling_direction: CirclingDirection::Right,
             vario_mode: VarioMode::Vario,
             vario_mode_control: VarioModeControl::Auto,
             vario_mode_switch_ratio: 1.10,

--- a/core/src/model/mod.rs
+++ b/core/src/model/mod.rs
@@ -15,7 +15,8 @@ pub use config::{
     UnitHorizontalSpeed, UnitVerticalSpeed,
 };
 pub use control::{
-    Control, DataSource, EditMode, FlyMode, SystemState, TcrMode, VarioMode, VarioModeControl,
+    CirclingDirection, Control, DataSource, EditMode, FlyMode, SystemState, TcrMode, VarioMode,
+    VarioModeControl,
 };
 use device::Device;
 pub use device_const::{

--- a/core/src/view/viewable/centerview.rs
+++ b/core/src/view/viewable/centerview.rs
@@ -1,11 +1,14 @@
 use crate::{
+    model::CirclingDirection, Colors, CoreError, CoreModel, DrawImage, FloatToSpeed, FlyMode,
+    VarioSizes,
+};
+use crate::{
     view::{
         sprites::{pos, Arrow, DrawStyled, PolarCoordinate, Rotate, WindArrow},
         thermal_data::{ThermalData, DELTA_ALPHA, THERMAL_DATA_CNT},
     },
     Image,
 };
-use crate::{Colors, CoreError, CoreModel, DrawImage, FloatToSpeed, FlyMode, VarioSizes};
 
 use embedded_graphics::{
     draw_target::DrawTarget,
@@ -152,11 +155,7 @@ where
     };
     let delta = DELTA_ALPHA;
 
-    let rotation = if cm.sensor.turn_rate.to_rad_s() > 0.0 {
-        -cm.sensor.euler_yaw.to_radians() + pos::NINE_O_CLOCK
-    } else {
-        -cm.sensor.euler_yaw.to_radians() + pos::THREE_O_CLOCK
-    };
+    let rotation = thermal_assistant_rotation(cm);
     thermal_data.prepare();
     for idx in 0..THERMAL_DATA_CNT {
         let (fill_color, delta_climb) = thermal_data.get_dotted_item(idx, cm);
@@ -173,14 +172,7 @@ where
     }
 
     let glider_img = Image::new(cm.device_const.images.small_glider);
-    let dy = (glider_img.height() / 2) as i32;
-    let p_gld = if cm.sensor.turn_rate.to_rad_s() > 0.0 {
-        let dx = (sizes.vario.ta_circle_radius + glider_img.width() / 2) as i32;
-        sizes.display.center + Point::new(-dx, -dy)
-    } else {
-        let dx = (sizes.vario.ta_circle_radius - glider_img.width() / 2) as i32;
-        sizes.display.center + Point::new(dx, -dy)
-    };
+    let p_gld = thermal_assistant_glider_pos(cm, &glider_img);
     glider_img.draw(display, p_gld, Some(cm.palette().vario.scale))
 }
 
@@ -200,11 +192,7 @@ where
     let delta = DELTA_ALPHA;
     let center = sizes.display.center;
 
-    let rotation = if cm.sensor.euler_roll.to_radians() > 0.0 {
-        -cm.sensor.euler_yaw.to_radians() + pos::NINE_O_CLOCK
-    } else {
-        -cm.sensor.euler_yaw.to_radians() + pos::THREE_O_CLOCK
-    };
+    let rotation = thermal_assistant_rotation(cm);
     thermal_data.prepare();
 
     let mut p1: Option<Point> = None;
@@ -239,15 +227,31 @@ where
         .draw(display)?;
 
     let glider_img = Image::new(cm.device_const.images.small_glider);
-    let dy = (glider_img.height() / 2) as i32;
-    let p_gld = if cm.sensor.turn_rate.to_rad_s() > 0.0 {
-        let dx = (sizes.vario.ta_circle_radius + glider_img.width() / 2) as i32;
-        sizes.display.center + Point::new(-dx, -dy)
-    } else {
-        let dx = (sizes.vario.ta_circle_radius - glider_img.width() / 2) as i32;
-        sizes.display.center + Point::new(dx, -dy)
-    };
+    let p_gld = thermal_assistant_glider_pos(cm, &glider_img);
     glider_img.draw(display, p_gld, Some(cm.palette().vario.scale))
+}
+
+fn thermal_assistant_rotation(cm: &CoreModel) -> f32 {
+    let yaw = -cm.sensor.euler_yaw.to_radians();
+    match cm.control.circling_direction {
+        CirclingDirection::Left => yaw + pos::NINE_O_CLOCK,
+        CirclingDirection::Right => yaw + pos::THREE_O_CLOCK,
+    }
+}
+
+fn thermal_assistant_glider_pos(cm: &CoreModel, glider_img: &Image) -> Point {
+    let sizes = &cm.device_const.sizes;
+    let dy = (glider_img.height() / 2) as i32;
+    match cm.control.circling_direction {
+        CirclingDirection::Left => {
+            let dx = (sizes.vario.ta_circle_radius + glider_img.width() / 2) as i32;
+            sizes.display.center + Point::new(-dx, -dy)
+        }
+        CirclingDirection::Right => {
+            let dx = (sizes.vario.ta_circle_radius - glider_img.width() / 2) as i32;
+            sizes.display.center + Point::new(dx, -dy)
+        }
+    }
 }
 
 fn draw_and_calc_wind_basics<D>(


### PR DESCRIPTION
## Summary

Use a turn-rate based circling direction detector for the thermal assistants.

Thermal Assistant 1 used turn rate directly, while Thermal Assistant 2 used AHRS roll. When roll/pitch are unavailable or stale, the spider assistant can choose the wrong orientation. This adds a shared circling direction state and uses it for both assistants.

## Changes

- Add `CirclingDirection` to `Control`.
- Update circling direction from significant `turn_rate` in the 100 ms controller tick.
- Keep the last direction when turn rate is near zero to avoid jitter.
- Make both thermal assistants use the shared detected direction for rotation and glider placement.