### PR TITLE
fix(#185): heal non-finite EEPROM f32s and confirm via editor review

### DIFF
--- a/core/src/controller/editor.rs
+++ b/core/src/controller/editor.rs
@@ -142,36 +142,51 @@ pub fn key_action(key_event: &mut KeyEvent, cm: &mut CoreModel, cc: &mut CoreCon
     if cm.control.editor.mode != EditMode::Off {
         match key_event {
             KeyEvent::BtnEnc => {
+                if cc.heal_review_active {
+                    persist::advance_heal_review(cm, cc);
+                    *key_event = KeyEvent::NoEvent;
+                    return;
+                }
                 cm.control.editor.enter_pushed = true;
                 let _ = cc.scheduler.stop(Timer::CloseEditFrame, true); // finish edit session
             }
             KeyEvent::BtnEncS3 => {
+                if cc.heal_review_active {
+                    // Heal review: only the encoder confirms; ignore long-press escape.
+                    *key_event = KeyEvent::NoEvent;
+                    return;
+                }
                 let _ = cc.scheduler.stop(Timer::CloseEditFrame, true); // finish edit session
                 close_menu_display(cm, cc); // close also menu and return to standard display
                 *key_event = KeyEvent::NoEvent;
             }
-            _ => cc
-                .scheduler
-                .after(crate::Timer::CloseEditFrame, SECTION_EDITOR_TIMEOUT.secs()),
+            _ => {
+                if !cc.heal_review_active {
+                    cc.scheduler
+                        .after(crate::Timer::CloseEditFrame, SECTION_EDITOR_TIMEOUT.secs());
+                }
+            }
         }
 
         let target = cm.control.editor.target;
 
         // change volume and mc cready independently of the selection
-        match target {
-            Editable::Volume => {
-                if *key_event == KeyEvent::Rotary1Left || *key_event == KeyEvent::Rotary1Right {
-                    activate_editable(Editable::McCready, cm, cc);
-                    *key_event = KeyEvent::NoEvent;
+        if !cc.heal_review_active {
+            match target {
+                Editable::Volume => {
+                    if *key_event == KeyEvent::Rotary1Left || *key_event == KeyEvent::Rotary1Right {
+                        activate_editable(Editable::McCready, cm, cc);
+                        *key_event = KeyEvent::NoEvent;
+                    }
                 }
-            }
-            Editable::McCready => {
-                if *key_event == KeyEvent::Rotary2Left || *key_event == KeyEvent::Rotary2Right {
-                    activate_editable(Editable::Volume, cm, cc);
-                    *key_event = KeyEvent::NoEvent;
+                Editable::McCready => {
+                    if *key_event == KeyEvent::Rotary2Left || *key_event == KeyEvent::Rotary2Right {
+                        activate_editable(Editable::Volume, cm, cc);
+                        *key_event = KeyEvent::NoEvent;
+                    }
                 }
+                _ => (),
             }
-            _ => (),
         }
 
         match cm.control.editor.params {
@@ -186,6 +201,10 @@ pub fn key_action(key_event: &mut KeyEvent, cm: &mut CoreModel, cc: &mut CoreCon
     if cm.config.display_active != DisplayActive::Menu
         && cm.config.overlay_active != OverlayActive::Menu
     {
+        if cc.heal_review_active {
+            // Do not open unrelated editors while confirming healed values.
+            return;
+        }
         match key_event {
             KeyEvent::Rotary1Left | KeyEvent::Rotary1Right => {
                 activate_editable(Editable::McCready, cm, cc);
@@ -234,6 +253,24 @@ pub fn key_action(key_event: &mut KeyEvent, cm: &mut CoreModel, cc: &mut CoreCon
 }
 
 pub fn activate_editable(editable: Editable, cm: &mut CoreModel, cc: &mut CoreController) {
+    activate_editable_inner(editable, cm, cc, true);
+}
+
+/// Same as activate_editable, but without auto-close (pilot must confirm healed values).
+pub fn activate_editable_for_heal_review(
+    editable: Editable,
+    cm: &mut CoreModel,
+    cc: &mut CoreController,
+) {
+    activate_editable_inner(editable, cm, cc, false);
+}
+
+fn activate_editable_inner(
+    editable: Editable,
+    cm: &mut CoreModel,
+    cc: &mut CoreController,
+    auto_close: bool,
+) {
     cm.control.editor.target = editable;
     cm.control.editor.params = editable.params(cm);
     cm.control.editor.content = editable.content(cm, cc);
@@ -244,8 +281,12 @@ pub fn activate_editable(editable: Editable, cm: &mut CoreModel, cc: &mut CoreCo
         cm.control.editor.mode = cm.device_const.misc.edit_mode;
     }
     cm.config.overlay_active = OverlayActive::Editor;
-    cc.scheduler
-        .after(crate::Timer::CloseEditFrame, SECTION_EDITOR_TIMEOUT.secs());
+    if auto_close {
+        cc.scheduler
+            .after(crate::Timer::CloseEditFrame, SECTION_EDITOR_TIMEOUT.secs());
+    } else {
+        let _ = cc.scheduler.stop(Timer::CloseEditFrame, false);
+    }
 
     // a command is executed when activating it - not during edit session
     if let Params::Cmd(_content) = cm.control.editor.params {
@@ -253,7 +294,11 @@ pub fn activate_editable(editable: Editable, cm: &mut CoreModel, cc: &mut CoreCo
     }
 }
 
-pub fn close_edit_frame(cm: &mut CoreModel, _cc: &mut CoreController) {
+pub fn close_edit_frame(cm: &mut CoreModel, cc: &mut CoreController) {
+    // Keep healed-value confirmation open until the encoder is pressed.
+    if cc.heal_review_active {
+        return;
+    }
     // Close Editor if open
     cm.control.editor.mode = EditMode::Off;
     cm.config.overlay_active = OverlayActive::None;

--- a/core/src/controller/mod.rs
+++ b/core/src/controller/mod.rs
@@ -32,7 +32,10 @@ mod tick_1s;
 use tick_1s::*;
 
 pub mod persist;
-pub use persist::{profile_always_0, store_persistence_ids, Echo, PersistenceId};
+pub use persist::{
+    advance_heal_review, editable_for_persisted_f32, maybe_start_heal_review, profile_always_0,
+    store_persistence_ids, Echo, PersistenceId, EEPROM_F32_IDS,
+};
 
 use crate::{
     basic_config::{CONTROLLER_TICK_RATE, MAX_TX_FRAMES},
@@ -73,6 +76,7 @@ pub enum Timer {
 }
 
 pub const MAX_PERS_IDS: usize = 8;
+pub const MAX_HEAL_REVIEW: usize = 32;
 
 pub struct CoreController {
     pub polar: Polar,
@@ -92,6 +96,10 @@ pub struct CoreController {
     pub pers_vals: FnvIndexMap<PersistenceId, PersistenceItem, MAX_PERS_IDS>,
     pub nmea_vals: FnvIndexSet<PersistenceId, MAX_PERS_IDS>,
     pub remote_val: Option<(CanConfigId, RemoteConfig)>,
+    /// Healed EEPROM f32 ids waiting for pilot confirmation via editor screens.
+    pub heal_queue: heapless::Vec<PersistenceId, MAX_HEAL_REVIEW>,
+    pub heal_review_active: bool,
+    pub heal_settle_ticks: u8,
     queue_to_idle_task: PIdleEvents,
     queue_from_idle_task: CPersistenceItems,
     p_tx_frames: PTxFrames<MAX_TX_FRAMES>,
@@ -141,10 +149,17 @@ impl CoreController {
             nmea_vals: FnvIndexSet::new(),
             pers_vals: FnvIndexMap::new(),
             remote_val: None,
+            heal_queue: heapless::Vec::new(),
+            heal_review_active: false,
+            heal_settle_ticks: 0,
             queue_to_idle_task,
             queue_from_idle_task,
             p_tx_frames,
         }
+    }
+
+    pub(crate) fn persistence_queue_ready(&self) -> bool {
+        self.queue_from_idle_task.ready()
     }
 
     pub fn event_handler(&mut self, event: Event, cm: &mut CoreModel) {
@@ -200,6 +215,8 @@ impl CoreController {
             core_model.sensor.turn_rate.to_rad_s(),
             core_model.control.circling_direction,
         );
+
+        persist::maybe_start_heal_review(core_model, self);
 
         if core_model.control.vario_mode == VarioMode::Vario {
             self.av2_climb_rate.tick(core_model.sensor.climb_rate);

--- a/core/src/controller/persist.rs
+++ b/core/src/controller/persist.rs
@@ -28,7 +28,9 @@ use crate::{
         RemoteConfig,
     },
     flight_physics::polar_store,
-    model::{GpsState, UnitHeight, UnitHorizontalSpeed, UnitVerticalSpeed},
+    model::{
+        GpsState, UnitHeight, UnitHorizontalSpeed, UnitVerticalSpeed, DisplayActive,
+    },
     set_snd_spreading_factor,
     system_of_units::Speed,
     utils::Variant,
@@ -36,8 +38,8 @@ use crate::{
         centerview::CenterView,
         vario_infoview::{Info3View, LineView},
     },
-    CanFrame, CoreController, CoreModel, DateTime, FloatToSpeed, Frame, GenericId, IdleEvent, Mass,
-    PersistenceItem, Pressure, Rotation, VarioMode, Waveform,
+    CanFrame, CoreController, CoreModel, DateTime, Editable, FloatToSpeed, Frame, GenericId,
+    IdleEvent, Mass, PersistenceItem, Pressure, Rotation, VarioMode, Waveform,
 };
 
 /// It is not permitted to change the sequence or assignment, as the number references the memory
@@ -209,10 +211,197 @@ pub enum Echo {
     NmeaAndCan,
 }
 
+/// Frontend-EEPROM f32 settings that are sanitized on restore.
+/// Order also defines heal-review presentation order.
+pub const EEPROM_F32_IDS: &[PersistenceId] = &[
+    PersistenceId::McCready,
+    PersistenceId::WaterBallast,
+    PersistenceId::PilotWeight,
+    PersistenceId::Qnh,
+    PersistenceId::Bugs,
+    PersistenceId::TcClimbRate,
+    PersistenceId::TcSpeedToFly,
+    PersistenceId::CenterFrequency,
+    PersistenceId::SoundSpreading,
+    PersistenceId::VarioUpperLimit,
+    PersistenceId::VarioLowerLimit,
+    PersistenceId::StfUpperLimit,
+    PersistenceId::StfLowerLimit,
+    PersistenceId::EmptyMass,
+    PersistenceId::MaxBallast,
+    PersistenceId::ReferenceWeight,
+    PersistenceId::PolarValueV1,
+    PersistenceId::PolarValueV2,
+    PersistenceId::PolarValueV3,
+    PersistenceId::PolarValueSi1,
+    PersistenceId::PolarValueSi2,
+    PersistenceId::PolarValueSi3,
+    PersistenceId::BatteryGood,
+    PersistenceId::BatteryLow,
+    PersistenceId::FlowEmpty,
+    PersistenceId::FlowSlope,
+    PersistenceId::EnergyArrowMult,
+];
+
+/// Map a healed EEPROM f32 id to its editor screen (None = heal only, no UI).
+pub fn editable_for_persisted_f32(id: PersistenceId) -> Option<Editable> {
+    match id {
+        PersistenceId::McCready => Some(Editable::McCready),
+        PersistenceId::WaterBallast => Some(Editable::WaterBallast),
+        PersistenceId::PilotWeight => Some(Editable::PilotWeight),
+        PersistenceId::Bugs => Some(Editable::Bugs),
+        PersistenceId::TcClimbRate => Some(Editable::TcClimbRate),
+        PersistenceId::TcSpeedToFly => Some(Editable::TcSpeedToFly),
+        PersistenceId::CenterFrequency => Some(Editable::CenterFrequency),
+        PersistenceId::SoundSpreading => Some(Editable::SoundSpreading),
+        PersistenceId::VarioUpperLimit => Some(Editable::VarioUpperLimit),
+        PersistenceId::VarioLowerLimit => Some(Editable::VarioLowerLimit),
+        PersistenceId::StfUpperLimit => Some(Editable::StfUpperLimit),
+        PersistenceId::StfLowerLimit => Some(Editable::StfLowerLimit),
+        PersistenceId::EmptyMass => Some(Editable::EmptyMass),
+        PersistenceId::MaxBallast => Some(Editable::MaxBallast),
+        PersistenceId::ReferenceWeight => Some(Editable::ReferenceWeight),
+        PersistenceId::PolarValueV1 => Some(Editable::PolarValueV1),
+        PersistenceId::PolarValueV2 => Some(Editable::PolarValueV2),
+        PersistenceId::PolarValueV3 => Some(Editable::PolarValueV3),
+        PersistenceId::PolarValueSi1 => Some(Editable::PolarValueSi1),
+        PersistenceId::PolarValueSi2 => Some(Editable::PolarValueSi2),
+        PersistenceId::PolarValueSi3 => Some(Editable::PolarValueSi3),
+        PersistenceId::BatteryGood => Some(Editable::BatteryGood),
+        PersistenceId::BatteryLow => Some(Editable::BatteryLow),
+        PersistenceId::FlowEmpty => Some(Editable::FlowEmpty),
+        PersistenceId::EnergyArrowMult => Some(Editable::EnergyArrowMult),
+        // QNH has no frontend Editable; FlowSlope is not in any menu — heal only.
+        _ => None,
+    }
+}
+
+fn enqueue_heal_review(cc: &mut CoreController, id: PersistenceId) {
+    if editable_for_persisted_f32(id).is_none() {
+        return;
+    }
+    if cc.heal_queue.iter().any(|&x| x == id) {
+        return;
+    }
+    let _ = cc.heal_queue.push(id);
+    cc.heal_settle_ticks = 0;
+}
+
+fn sort_heal_queue(cc: &mut CoreController) {
+    cc.heal_queue.as_mut_slice().sort_unstable_by_key(|id| {
+        EEPROM_F32_IDS
+            .iter()
+            .position(|&x| x == *id)
+            .unwrap_or(usize::MAX)
+    });
+}
+
+/// After EEPROM restore has settled, open the first healed setting for pilot confirmation.
+pub fn maybe_start_heal_review(cm: &mut CoreModel, cc: &mut CoreController) {
+    if cc.heal_review_active || cc.heal_queue.is_empty() {
+        return;
+    }
+    // Wait until the idle→controller restore queue is empty and stays empty briefly.
+    if cc.persistence_queue_ready() {
+        cc.heal_settle_ticks = 0;
+        return;
+    }
+    cc.heal_settle_ticks = cc.heal_settle_ticks.saturating_add(1);
+    if cc.heal_settle_ticks < 5 {
+        return;
+    }
+    cc.heal_review_active = true;
+    cc.heal_settle_ticks = 0;
+    sort_heal_queue(cc);
+    show_next_heal_editable(cm, cc);
+}
+
+/// Encoder confirm during heal review: accept current value and show the next healed setting.
+pub fn advance_heal_review(cm: &mut CoreModel, cc: &mut CoreController) {
+    if !cc.heal_review_active {
+        return;
+    }
+    if !cc.heal_queue.is_empty() {
+        let _ = cc.heal_queue.remove(0);
+    }
+    show_next_heal_editable(cm, cc);
+}
+
+fn show_next_heal_editable(cm: &mut CoreModel, cc: &mut CoreController) {
+    while let Some(&id) = cc.heal_queue.first() {
+        if let Some(editable) = editable_for_persisted_f32(id) {
+            // Keep the pilot on the vario surface with the standard editor overlay.
+            if cm.config.display_active == DisplayActive::Menu {
+                cm.config.display_active = DisplayActive::Vario;
+            }
+            crate::controller::editor::activate_editable_for_heal_review(editable, cm, cc);
+            return;
+        }
+        let _ = cc.heal_queue.remove(0);
+    }
+    cc.heal_review_active = false;
+    crate::controller::editor::close_edit_frame(cm, cc);
+}
+
+/// Boot defaults for f32 values stored in frontend EEPROM (same numbers as Config /
+/// GliderData / DrainControl / Control defaults). Polar-related defaults follow the
+/// currently selected glider (Glider is restored before EmptyMass..PolarSi).
+fn persisted_f32_default(cm: &CoreModel, id: PersistenceId) -> Option<f32> {
+    let polar = {
+        let idx = cm.config.glider_idx as usize;
+        if idx < polar_store::POLARS.len() {
+            &polar_store::POLARS[idx]
+        } else {
+            &polar_store::POLARS[0]
+        }
+    };
+    match id {
+        PersistenceId::McCready => Some(0.7),
+        PersistenceId::WaterBallast => Some(0.0),
+        PersistenceId::PilotWeight => Some(90.0),
+        PersistenceId::Qnh => Some(Pressure::AT_NN().to_hpa()),
+        PersistenceId::Bugs => Some(1.0),
+        PersistenceId::TcClimbRate => Some(30.0),
+        PersistenceId::TcSpeedToFly => Some(5.0),
+        PersistenceId::CenterFrequency => Some(659.0),
+        PersistenceId::EmptyMass => Some(polar.empty_mass),
+        PersistenceId::MaxBallast => Some(polar.max_ballast),
+        PersistenceId::ReferenceWeight => Some(polar.reference_weight),
+        PersistenceId::PolarValueV1 => Some(polar.polar_values[0][0]),
+        PersistenceId::PolarValueV2 => Some(polar.polar_values[1][0]),
+        PersistenceId::PolarValueV3 => Some(polar.polar_values[2][0]),
+        PersistenceId::PolarValueSi1 => Some(polar.polar_values[0][1]),
+        PersistenceId::PolarValueSi2 => Some(polar.polar_values[1][1]),
+        PersistenceId::PolarValueSi3 => Some(polar.polar_values[2][1]),
+        PersistenceId::BatteryGood => Some(11.5),
+        PersistenceId::BatteryLow => Some(10.0),
+        PersistenceId::FlowEmpty => Some(30.0),
+        PersistenceId::FlowSlope => Some(0.0),
+        PersistenceId::StfUpperLimit => Some(10.0.km_h().to_m_s()),
+        PersistenceId::StfLowerLimit => Some((-10.0).km_h().to_m_s()),
+        PersistenceId::EnergyArrowMult => Some(0.0),
+        PersistenceId::VarioUpperLimit => Some(0.0),
+        PersistenceId::VarioLowerLimit => Some(0.0),
+        PersistenceId::SoundSpreading => Some(1.0),
+        _ => None,
+    }
+}
+
+/// Replace non-finite f32 EEPROM payloads with the boot default for that id.
+fn sanitize_f32_item(cm: &CoreModel, item: PersistenceItem) -> (PersistenceItem, bool) {
+    if let Some(default) = persisted_f32_default(cm, item.id) {
+        if !item.to_f32().is_finite() {
+            return (PersistenceItem::from_f32(item.id, default), true);
+        }
+    }
+    (item, false)
+}
+
 /// Store item content into data model
 ///
 /// This method is also called directly from the idle-loop during start-up
 pub fn restore_item(cc: &mut CoreController, cm: &mut CoreModel, item: PersistenceItem) {
+    let (item, healed) = sanitize_f32_item(cm, item);
     match item.id {
         PersistenceId::Volume => cm.config.volume = item.to_i8(),
         PersistenceId::McCready => cm.config.mc_cready = Speed::from_m_s(item.to_f32()),
@@ -350,6 +539,13 @@ pub fn restore_item(cc: &mut CoreController, cm: &mut CoreModel, item: Persisten
         PersistenceId::DoNotStore => (),
         PersistenceId::LastItem => (),
     }
+
+    // Rewrite healed values to EEPROM so a power cycle does not restore NaN/Inf again.
+    // Use SetEepromItem directly: pers_vals only holds a few entries.
+    if healed && (item.id as u16) < (PersistenceId::LastItem as u16) {
+        cc.send_idle_event(IdleEvent::SetEepromItem(item));
+        enqueue_heal_review(cc, item.id);
+    }
 }
 
 pub fn persist_set(
@@ -360,6 +556,7 @@ pub fn persist_set(
     echo: Echo,
 ) {
     let item = PersistenceItem::from_variant(id, variant);
+    let (item, _) = sanitize_f32_item(cm, item);
     restore_item(cc, cm, item);
 
     if id == PersistenceId::Glider {

--- a/device/sim/src/adapt.rs
+++ b/device/sim/src/adapt.rs
@@ -176,7 +176,8 @@ impl AdaptInner  {
                 Com::LogWindowSave(path)
             } 
             "\u{f707}" => Com::LogWindowClear,
-
+            "\u{f710}" => Com::CorruptAllEepromF32,
+            "\u{f711}" => Com::CorruptRandomEepromF32,
 
             "\u{f708}" | "\n" => Com::Event(Event::KeyItem(KeyEvent::BtnEnc)), 
             "\u{f709}" => Com::Event(Event::KeyItem(KeyEvent::BtnEncS3)),

--- a/device/sim/src/frontend.rs
+++ b/device/sim/src/frontend.rs
@@ -16,6 +16,52 @@ use crate::{
 
 use super::Lcd;
 
+/// Quiet NaN bit pattern observed in field dumps (`0x7fc00000`).
+const QUIET_NAN_BITS: u32 = 0x7fc00000;
+
+fn corrupt_eeprom_f32_ids(
+    eeprom: &mut Eeprom<Storage>,
+    ids: impl IntoIterator<Item = PersistenceId>,
+) {
+    let nan = f32::from_bits(QUIET_NAN_BITS);
+    println!("Corrupting EEPROM f32 slots with quiet NaN 0x{QUIET_NAN_BITS:08x}:");
+    for id in ids {
+        let item = PersistenceItem::from_f32(id, nan);
+        println!("  {:?} = {} (bits 0x{:08x})", id, nan, nan.to_bits());
+        eeprom.write_item(item).unwrap();
+    }
+    println!("EEPROM corrupted — quitting so you can `cargo run` again to exercise heal+review.");
+    quit_event_loop().unwrap();
+}
+
+fn corrupt_all_eeprom_f32(eeprom: &mut Eeprom<Storage>) {
+    corrupt_eeprom_f32_ids(eeprom, EEPROM_F32_IDS.iter().copied());
+}
+
+fn corrupt_random_eeprom_f32(eeprom: &mut Eeprom<Storage>) {
+    let mut seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(1);
+    let mut next = || {
+        // Simple LCG — good enough for sim test selection.
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        seed
+    };
+
+    let mut chosen = vec::Vec::new();
+    for &id in EEPROM_F32_IDS {
+        if next() & 1 == 1 {
+            chosen.push(id);
+        }
+    }
+    if chosen.is_empty() {
+        let idx = (next() as usize) % EEPROM_F32_IDS.len();
+        chosen.push(EEPROM_F32_IDS[idx]);
+    }
+    corrupt_eeprom_f32_ids(eeprom, chosen);
+}
+
 fn millis() -> u16 {
     let since_the_epoch = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -277,6 +323,8 @@ impl Frontend {
                         Com::LogWindowPause => logger.pause(),
                         Com::LogWindowSave(path) => logger.save(path),
                         Com::LogWindowClear => logger.clear(),
+                        Com::CorruptAllEepromF32 => corrupt_all_eeprom_f32(&mut eeprom),
+                        Com::CorruptRandomEepromF32 => corrupt_random_eeprom_f32(&mut eeprom),
                     }
                 };
 

--- a/device/sim/src/main.rs
+++ b/device/sim/src/main.rs
@@ -43,6 +43,10 @@ pub enum Com {
     LogWindowPause,
     LogWindowSave(Option<PathBuf>),
     LogWindowClear,
+    /// Write quiet NaN into every frontend-EEPROM f32 slot, print, then hard-quit.
+    CorruptAllEepromF32,
+    /// Write quiet NaN into a random subset of EEPROM f32 slots, print, then hard-quit.
+    CorruptRandomEepromF32,
 }
 
 

--- a/device/sim/ui/log-window.slint
+++ b/device/sim/ui/log-window.slint
@@ -119,6 +119,18 @@ export component Log-Window inherits Window {
                         text: "Clear"; 
                     }
                     Text { vertical-stretch: 1; }
+                    Button {
+                        text: "Corrupt all f32";
+                        clicked => {
+                            Global.process-command("\u{f710}")
+                        }
+                    }
+                    Button {
+                        text: "Corrupt random f32";
+                        clicked => {
+                            Global.process-command("\u{f711}")
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Sanitize non-finite frontend EEPROM f32 values to boot defaults on restore and write them back
- After restore settles, walk the pilot through editor confirmation (no auto-timeout; QNH/FlowSlope heal-only)
- Sim log window: corrupt all/random f32 EEPROM slots, print, hard-quit for retest

## Test plan
- [x] Sim: Corrupt all f32 → restart → confirm each healed editor screen with encoder
- [x] Sim: Corrupt random → restart → only corrupted editable ids appear in review
- [x] After review, values persist across another restart
- [x] Normal menu/rotary editing still works when no heal is pending

Addresses #185 (EEPROM NaN heal / confirm review only; other #185 items remain open).