### PR TITLE
fix(#185): return 0 ballast fraction when max_ballast is 0

### DIFF
--- a/core/src/flight_physics/polar.rs
+++ b/core/src/flight_physics/polar.rs
@@ -42,11 +42,22 @@ impl GliderData {
     }
 
     pub fn ballast_fraction(&self) -> f32 {
-        self.water_ballast.to_kg() / self.basic_glider_data.max_ballast
+        let max = self.basic_glider_data.max_ballast;
+        // Polars with no water tanks use max_ballast = 0; never divide (NaN/Inf
+        // on the CAN ballast fraction crashes the sensorbox NMEA formatter).
+        if !(max > 0.0) {
+            return 0.0;
+        }
+        self.water_ballast.to_kg() / max
     }
 
     pub fn set_ballast_fraction(&mut self, fraction: f32) {
-        self.water_ballast = (fraction * self.basic_glider_data.max_ballast).kg();
+        let max = self.basic_glider_data.max_ballast;
+        if !(max > 0.0) {
+            self.water_ballast = 0.0.kg();
+            return;
+        }
+        self.water_ballast = (fraction * max).kg();
     }
 
     pub fn bugs(&self) -> f32 {
@@ -269,6 +280,23 @@ mod tests {
         polar.recalc(&glider_data, Density::AT_NN());
 
         write_stf_to_csv("tests/as33.csv", &mut polar);
+    }
+
+    #[test]
+    fn test_ballast_fraction_max_zero() {
+        let mut glider_data = GliderData::default();
+        glider_data.basic_glider_data.max_ballast = 0.0;
+        glider_data.water_ballast = 50.0.kg();
+
+        assert_eq!(glider_data.ballast_fraction(), 0.0);
+
+        glider_data.set_ballast_fraction(0.5);
+        assert_eq!(glider_data.water_ballast.to_kg(), 0.0);
+        assert_eq!(glider_data.ballast_fraction(), 0.0);
+
+        glider_data.basic_glider_data.max_ballast = 100.0;
+        glider_data.water_ballast = 25.0.kg();
+        assert_eq!(glider_data.ballast_fraction(), 0.25);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Guard `ballast_fraction` / `set_ballast_fraction` so `max_ballast <= 0` never divides and returns/applies 0
- Prevents Inf/NaN ballast fraction on CAN/NMEA sync that crashed the sensorbox `$PLARS,L,BAL` formatter
- Unit test covers max-zero and normal fraction paths

## Test plan
- [x] `cargo test test_ballast_fraction_max_zero` in `core`
- [ ] Sim/device: polar with `max_ballast = 0` does not send non-finite BAL / no sensorbox reset loop
- [ ] Polar with positive max ballast still reports `water/max` as before

Addresses #185 (max_ballast = 0 ballast fraction only; other #185 items remain open).